### PR TITLE
direct to stacspec.org while tutorial is being developed

### DIFF
--- a/tutorials/stac/python/python-read-stac/index.ipynb
+++ b/tutorials/stac/python/python-read-stac/index.ipynb
@@ -62,9 +62,31 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Collecting pystac\n",
+      "  Downloading pystac-1.12.2-py3-none-any.whl.metadata (4.6 kB)\n",
+      "Collecting python-dateutil>=2.7.0 (from pystac)\n",
+      "  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)\n",
+      "Collecting six>=1.5 (from python-dateutil>=2.7.0->pystac)\n",
+      "  Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)\n",
+      "Downloading pystac-1.12.2-py3-none-any.whl (194 kB)\n",
+      "Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)\n",
+      "Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)\n",
+      "Installing collected packages: six, python-dateutil, pystac\n",
+      "Successfully installed pystac-1.12.2 python-dateutil-2.9.0.post0 six-1.17.0\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
-    "# ! pip install pystac"
+    "! pip install pystac"
    ]
   },
   {
@@ -164,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -198,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -233,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -296,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -352,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -384,7 +406,7 @@
        "   [-76.12180471942207, 39.95810181489563]]]}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -395,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -404,7 +426,7 @@
        "[-76.66703, 37.82561, -73.94861, 39.95958]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -415,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -424,7 +446,7 @@
        "datetime.datetime(2018, 6, 15, 15, 39, 9, tzinfo=tzutc())"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -435,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -444,7 +466,7 @@
        "'landsat-8-l1'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -462,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1784,7 +1806,7 @@
        "<Collection id=landsat-8-l1>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1804,7 +1826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1813,7 +1835,7 @@
        "['OLI_TIRS']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1824,7 +1846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1833,7 +1855,7 @@
        "'landsat-8'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1844,7 +1866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1853,7 +1875,7 @@
        "30"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1873,7 +1895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1884,7 +1906,7 @@
        " 'https://stac-extensions.github.io/projection/v2.0.0/schema.json']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1904,7 +1926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1913,7 +1935,7 @@
        "True"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1924,7 +1946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1933,7 +1955,7 @@
        "False"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1951,7 +1973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1960,7 +1982,7 @@
        "22"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1979,7 +2001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1988,7 +2010,7 @@
        "22"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2013,7 +2035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -2054,7 +2076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -2070,7 +2092,7 @@
        " 'roles': []}"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2089,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -2098,7 +2120,7 @@
        "[<Band name=B3>]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2111,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -2123,7 +2145,7 @@
        " 'common_name': 'green'}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2136,7 +2158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You have now successfully explored the common components of an existing STAC Catalog. To learn how to write your own STAC Catalog, see the [following tutorial](/en/tutorials/2-create-stac-catalog-python/index.html)."
+    "You have now successfully explored the common components of an existing STAC Catalog. To learn how to write your own STAC Catalog, see the [following tutorial](https://stacspec.org/en/tutorials/2-create-stac-catalog-python/)."
    ]
   },
   {


### PR DESCRIPTION
Testing out the work flow of contributing.

There is a dead link at the bottom of the read STAC tutorial. I updated the link to point to stacspec.org for now. I assume you are planning on creating a codespace for that tutorial as well.